### PR TITLE
Use the gem bindir ./exe/ to avoid publishing binstubs as part of the…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 notifications:
   email: false
 rvm:
-  - 2.2.1
+  - 2.2.5
+  - 2.3.1
+
 before_install:
   - gem install bundler 

--- a/assembly-utils.gemspec
+++ b/assembly-utils.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.bindir        = 'exe'
+  s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
   s.add_dependency 'nokogiri'


### PR DESCRIPTION
… gem
