### PR TITLE
Update test grid to test on ruby 2.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: ruby
 notifications:
   email: false
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.5.3
 
 before_install:
   - gem install bundler 


### PR DESCRIPTION
All infrastructure projects now use 2.5.3