### PR TITLE
Bump the tested ruby version to 2.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: ruby
 notifications:
   email: false
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.5.3
 
 before_install:
-  - gem install bundler 
+  - gem install bundler


### PR DESCRIPTION
All the dependents (pre-assembly and common-accessioning) are on 2.5.3